### PR TITLE
feat(localization): fluent prototype for i18n/l10n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ name = "aho-corasick"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -289,6 +289,8 @@ version = "0.1.0"
 dependencies = [
  "cacache 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluent 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)",
+ "fluent-locale 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssri 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,6 +361,45 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide_c_api 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fluent"
+version = "0.6.0"
+source = "git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc#605ec0e50b130f993d044af1354c75fd83222492"
+dependencies = [
+ "fluent-bundle 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.6.0"
+source = "git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc#605ec0e50b130f993d044af1354c75fd83222492"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluent-locale 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "intl_pluralrules 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fluent-locale"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fluent-locale"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unic-locale 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fnv"
@@ -478,7 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.12.31"
+version = "0.12.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -512,7 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -531,6 +572,15 @@ dependencies = [
 name = "indexmap"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "intl_pluralrules"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iovec"
@@ -592,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1031,7 +1081,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1054,6 +1104,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rental"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,7 +1135,7 @@ dependencies = [
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1489,6 +1558,19 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unic-langid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unic-locale"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unic-langid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1762,11 @@ dependencies = [
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
+"checksum fluent 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)" = "<none>"
+"checksum fluent-bundle 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)" = "<none>"
+"checksum fluent-locale 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a54a80f8d4153a0390516480b155b8495408f00a4eebd386ed4d7b4532c7e01"
+"checksum fluent-locale 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c86c49a9d48a46a59fa52fee755eb614646e5fa86f928ea0d0c6ed8505247bff"
+"checksum fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd33f0ec4141fae9f6d6183c30504275b8a4c843b02517d17098593244ad4617"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -1695,10 +1782,11 @@ dependencies = [
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-"checksum hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)" = "6481fff8269772d4463253ca83c788104a7305cb3fb9136bc651a6211e46e03f"
+"checksum hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)" = "a64d71c1e77d39da024f06f5821ee00ad9c38febb90370bad1f07a94e0bc8793"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum intl_pluralrules 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "44e8cf904cd38f8191ce5c12adaad9f00eb984d2717b9783f6cf1b27131b18ae"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -1707,7 +1795,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
@@ -1759,6 +1847,8 @@ dependencies = [
 "checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
 "checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "01916ebd9fc2e81978a5dc9542a2fa47f5bb2ca3402e14c7cc42d6e3c5123e1f"
+"checksum rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82260d54cf2cbe9608df161f7e7c98e81fae702aa13af9e4d5d39dc2ffb25ab6"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -1805,6 +1895,8 @@ dependencies = [
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unic-langid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6c7f51a6dc6f4a408ac576bac0288feae5b3351b2a2009810ae60a1462f37a"
+"checksum unic-locale 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137e6adb97a41eb4676b89f61a76754f28cec70dc1edb895d74c9fbbe4e3d131"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ version = "0.1.0"
 dependencies = [
  "cacache 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fluent 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)",
+ "fluent 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/)",
  "fluent-locale 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,15 +365,15 @@ dependencies = [
 [[package]]
 name = "fluent"
 version = "0.6.0"
-source = "git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc#605ec0e50b130f993d044af1354c75fd83222492"
+source = "git+https://github.com/zbraniecki/fluent-rs/#d37df07b6ede8d5fe7188222db7d0104c41561ba"
 dependencies = [
- "fluent-bundle 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)",
+ "fluent-bundle 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/)",
 ]
 
 [[package]]
 name = "fluent-bundle"
 version = "0.6.0"
-source = "git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc#605ec0e50b130f993d044af1354c75fd83222492"
+source = "git+https://github.com/zbraniecki/fluent-rs/#d37df07b6ede8d5fe7188222db7d0104c41561ba"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -381,6 +381,7 @@ dependencies = [
  "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "intl_pluralrules 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1762,8 +1763,8 @@ dependencies = [
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
-"checksum fluent 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)" = "<none>"
-"checksum fluent-bundle 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/?branch=res-rc)" = "<none>"
+"checksum fluent 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/)" = "<none>"
+"checksum fluent-bundle 0.6.0 (git+https://github.com/zbraniecki/fluent-rs/)" = "<none>"
 "checksum fluent-locale 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a54a80f8d4153a0390516480b155b8495408f00a4eebd386ed4d7b4532c7e01"
 "checksum fluent-locale 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c86c49a9d48a46a59fa52fee755eb614646e5fa86f928ea0d0c6ed8505247bff"
 "checksum fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd33f0ec4141fae9f6d6183c30504275b8a4c843b02517d17098593244ad4617"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33.0"
 cacache = "1.0.1"
-fluent = { git = "https://github.com/zbraniecki/fluent-rs/", branch = "res-rc" }
+fluent = { git = "https://github.com/zbraniecki/fluent-rs/" }
 fluent-locale = "0.5.0"
 ssri = "3.0.0"
 reqwest = "0.9.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 [dependencies]
 clap = "2.33.0"
 cacache = "1.0.1"
+fluent = { git = "https://github.com/zbraniecki/fluent-rs/", branch = "res-rc" }
+fluent-locale = "0.5.0"
 ssri = "3.0.0"
 reqwest = "0.9.18"
 log = "0.4.6"

--- a/locales/en-US/hello.ftl
+++ b/locales/en-US/hello.ftl
@@ -1,0 +1,1 @@
+hello-world = Hello world!

--- a/locales/es-MX/hello.ftl
+++ b/locales/es-MX/hello.ftl
@@ -1,0 +1,1 @@
+hello-world = Hola mundo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@
 
 pub mod parse_args;
 pub mod fetch;
+pub mod localization;

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -1,0 +1,104 @@
+use std::fs;
+use std::io;
+use std::sync::Arc;
+
+use fluent::{FluentBundle, FluentResource};
+use fluent_locale::{negotiate_languages, NegotiationStrategy};
+
+const L10N_RESOURCES: &[&str] = &["hello.ftl"];
+const LOCALES_PATH: &str = "./locales";
+
+fn read_file(path: &str) -> Result<String, io::Error> {
+    let s = fs::read_to_string(path)?;
+    Ok(s)
+}
+
+pub fn get_resources(requested: &str) -> Result<Vec<Arc<FluentResource>>, io::Error> {
+    let mut resources: Vec<Arc<FluentResource>> = vec![];
+    let locales = get_app_locales(&[requested]).expect("Failed to retrieve available locales");
+
+    for path in L10N_RESOURCES {
+        let full_path = format!(
+            "{LOCALES_PATH}/{locale}/{path}",
+            LOCALES_PATH = LOCALES_PATH,
+            locale = locales[0],
+            path = path
+        );
+        let source = read_file(&full_path).expect("Failed to read file.");
+        let resource = FluentResource::try_new(source).expect("Could not parse an FTL string.");
+        resources.push(Arc::new(resource));
+    }
+
+    Ok(resources)
+}
+
+pub fn get_resource_bundle(requested: &str) -> Result<FluentBundle, io::Error> {
+    let locales = get_app_locales(&[requested]).expect("Failed to retrieve available locales");
+    let mut bundle = FluentBundle::new(&locales);
+
+    let resources = get_resources(requested)?;
+
+    for res in resources {
+        bundle
+            .add_resource(res)
+            .expect("Failed to add resource to the bundle");
+    }
+
+   Ok(bundle)
+}
+
+pub fn get_locales() -> Result<Vec<String>, io::Error> {
+    let mut locales = vec![];
+    let res_dir = fs::read_dir(LOCALES_PATH)?;
+
+    for entry in res_dir {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name() {
+                    if let Some(name) = name.to_str() {
+                        locales.push(String::from(name));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(locales)
+}
+
+fn get_app_locales(requested: &[&str]) -> Result<Vec<String>, io::Error> {
+    let available = get_locales()?;
+    let resolved_locales = negotiate_languages(
+        requested,
+        &available,
+        Some("en-US"),
+        &NegotiationStrategy::Filtering,
+    );
+    return Ok(resolved_locales
+        .into_iter()
+        .map(|s| String::from(s))
+        .collect::<Vec<String>>());
+}
+
+#[cfg(test)]
+mod test {
+    use crate::localization::get_resource_bundle;
+
+    #[test]
+    pub fn test_get_resource_bundle() {
+        let es_mx_locale = "es-MX";
+        let es_mx_bundle = get_resource_bundle(es_mx_locale).unwrap();
+        let (es_mx_value, _) = es_mx_bundle
+                    .format("hello-world", None)
+                    .expect("Failed to format a message");
+        assert_eq!(es_mx_value, String::from("Hola mundo"));
+
+        let en_us_locale = "en-US";
+        let en_us_bundle = get_resource_bundle(en_us_locale).unwrap();
+        let (en_us_value, _) = en_us_bundle
+                    .format("hello-world", None)
+                    .expect("Failed to format a message");
+        assert_eq!(en_us_value, String::from("Hello world!"));
+    }
+}

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::io;
-use std::sync::Arc;
 
 use fluent::{FluentBundle, FluentResource};
 use fluent_locale::{negotiate_languages, NegotiationStrategy};
@@ -13,8 +12,8 @@ fn read_file(path: &str) -> Result<String, io::Error> {
     Ok(s)
 }
 
-pub fn get_resources(requested: &str) -> Result<Vec<Arc<FluentResource>>, io::Error> {
-    let mut resources: Vec<Arc<FluentResource>> = vec![];
+pub fn get_resources(requested: &str) -> Result<Vec<FluentResource>, io::Error> {
+    let mut resources: Vec<FluentResource> = vec![];
     let locales = get_app_locales(&[requested]).expect("Failed to retrieve available locales");
 
     for path in L10N_RESOURCES {
@@ -26,13 +25,13 @@ pub fn get_resources(requested: &str) -> Result<Vec<Arc<FluentResource>>, io::Er
         );
         let source = read_file(&full_path).expect("Failed to read file.");
         let resource = FluentResource::try_new(source).expect("Could not parse an FTL string.");
-        resources.push(Arc::new(resource));
+        resources.push(resource);
     }
 
     Ok(resources)
 }
 
-pub fn get_resource_bundle(requested: &str) -> Result<FluentBundle, io::Error> {
+pub fn get_resource_bundle(requested: &str) -> Result<FluentBundle<FluentResource>, io::Error> {
     let locales = get_app_locales(&[requested]).expect("Failed to retrieve available locales");
     let mut bundle = FluentBundle::new(&locales);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,4 +4,13 @@ use std::fs;
 fn main() {
     dstopic::parse_args::parse_args().get_matches();
     println!("{}", fs::read_to_string("./Cargo.toml").unwrap().len());
+
+
+    let locale = "en-US";
+    let bundle = dstopic::localization::get_resource_bundle(locale).unwrap();
+
+    let (value, _) = bundle
+        .format("hello-world", None)
+        .expect("Failed to format a message");
+    println!("{}", value);
 }


### PR DESCRIPTION
This is a prototype using fluent for localization. It is based on the simple app in the examples.

The main problem that I was having with fluent was if you want to make a module with some helper functions it becomes difficult due to the way you have to add a `FluentResource` to a `FluentBundle`.

There is a PR out to [swap passing a reference of a `FluentResource` to a `FluentBundle`](https://github.com/projectfluent/fluent-rs/pull/112) and I have pinned the `fluent` package to that branch for now. It made it much nicer because then you can wrap the `FluentResource` in an `Arc` and it just works.

If we decide to move forward with this we should probably shuffle some stuff around and write docs and all that, but wanted to get a prototype out so folks could get an idea of what fluent looks like.